### PR TITLE
Initialize pending order attribute in strategies

### DIFF
--- a/src/valueinvestpy/backtesting/strategies/logistic_regression.py
+++ b/src/valueinvestpy/backtesting/strategies/logistic_regression.py
@@ -37,6 +37,9 @@ class LogisticRegressionStrategy(bt.Strategy):
         # Keep a reference to the close price data feed
         self.dataclose = self.datas[0].close
 
+        # Track pending orders to avoid double submissions
+        self.order = None
+
     def next(self):
         """
         Executes on each bar of data, generates a prediction, and places an order.

--- a/src/valueinvestpy/backtesting/strategies/svm.py
+++ b/src/valueinvestpy/backtesting/strategies/svm.py
@@ -38,6 +38,9 @@ class SVMStrategy(bt.Strategy):
         # Keep a reference to the close price data feed
         self.dataclose = self.datas[0].close
 
+        # Track pending orders to avoid repeated submissions
+        self.order = None
+
     def next(self):
         """
         Executes on each bar of data, generates a prediction, and places an order.

--- a/src/valueinvestpy/backtesting/strategies/svm_technical.py
+++ b/src/valueinvestpy/backtesting/strategies/svm_technical.py
@@ -39,6 +39,9 @@ class SVMTechnicalStrategy(bt.Strategy):
         self.sma = sma(self.datas[0].close, window=self.p.ma_period)
         self.rsi = rsi(self.datas[0].close, window=self.p.rsi_period)
 
+        # Track pending orders
+        self.order = None
+
     def next(self):
         """
         Executes on each bar, generates features and a prediction, and places an order.


### PR DESCRIPTION
## Summary
- prevent `AttributeError` when using machine learning strategies
- add `order` initialization to logistic regression, SVM, and SVM technical strategies

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879ebafe6548332a083eb407be568da